### PR TITLE
Update Pandocfilters to Version 1.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pandocfilters" %}
-{% set version = "1.4.3" %}
-{% set sha256 = "bc63fbb50534b4b1f8ebe1860889289e8af94a23bff7445259592df25a3906eb" %}
+{% set version = "1.5.0" %}
+{% set sha256 = "0b679503337d233b4339a817bfc8c50064e2eff681314376a47cb582305a7a38" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,28 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
+  skip: True  # [py<36]
   script: pip install --no-deps .
 
 requirements:
   host:
     - python
     - pip
+    - wheel
+    - setuptools
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:
     - pandocfilters
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    - pip check
+
 
 about:
   home: https://github.com/jgm/pandocfilters
@@ -34,6 +43,8 @@ about:
   summary: 'A python module for writing pandoc filters'
 
   dev_url: https://github.com/jgm/pandocfilters
+  # the documentation was updated according to pypi.org
+  doc_url: https://pandoc.org/filters.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION

pandocfilters 1.5.0

1. check the upstream
https://github.com/jgm/pandocfilters/tree/1.5.0

2. check the pinnings
https://github.com/jgm/pandocfilters/blob/1.5.0/setup.py
https://github.com/jgm/pandocfilters/blob/1.5.0/setup.cfg
https://github.com/jgm/pandocfilters/blob/1.5.0/pandocfilters.py

3. check changelogs
https://github.com/jgm/pandocfilters/blob/1.5.0/CHANGELOG.md

4. additional research
https://github.com/conda-forge/pandocfilters-feedstock/issues

There are no open issues mentioned at the time of the review

5. verify dev_url
    https://github.com/jgm/pandocfilters

6. verify doc_url
    There is not doc_url after doing some research the following documentation seems to be indicated in pypi.org

        https://pandoc.org/filters.html

7. added pip to the test section
8. verify the test section
9. additional tests

In order to test the `pandocfilters` package version `1.5.0` the following command was used:
`conda build pandocfilters-feedstock --test` 
The test result was the following:
`All tests passed`

In additional the `nbconvert` package was used for additional testing
the following command was used:
`conda build nbconvert-feedstock --test` 
The test result was the following:
`All tests passed`

Based on the research findings and on the test results we can conclude that it is safe to update `pandocfilters` to version `1.5.0`

