### PR TITLE
update `pandocfilter` to version `1.5.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,9 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python
+    # The package is not supported for the versions 3.0 to 3.3 of python
+    # https://github.com/jgm/pandocfilters/blob/master/setup.py#L19
+    - python !=3.0,!=3.1,!=3.2,!=3.3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
     - pandocfilters
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  noarch: python
   script: pip install --no-deps .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,14 +23,13 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
     - pandocfilters
   requires:
     - pip
-    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION

  `pandocfilters` version `1.5.0`
1. - [x] check the upstream
    https://github.com/jgm/pandocfilters/tree/1.5.0

2. - [x] check the pinnings

https://github.com/jgm/pandocfilters/blob/1.5.0/setup.py

https://github.com/jgm/pandocfilters/blob/1.5.0/pandocfilters.py


3. - [x] check the changelogs
    https://github.com/jgm/pandocfilters/tree/1.5.0/CHANGELOG.md

    this will be the last version supporting python 2

4. - [x] additional research
    https://github.com/conda-forge/pandocfilters-feedstock/issues

    - there are currently no open issue at the time of the review on `conda-forge`

5. - [x] verify dev_url
    https://github.com/jgm/pandocfilters

6. - [x] verify doc_url
      - https://pandoc.org/filters.html
7. - [x] license is spdx compliant
      - BSD-3-Clause
8. - [x] license family
      - BSD
9. - [x] verify the build number
      - the build number is set to zero
10. - [x] verify setuptools
      - setuptools is included in the recipe
11. - [x] verify wheel
      - wheel is in the recipe
12. - [x] pip in the test section
13. - [x] veriy the test section

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `pandocfilters` to version `1.5.0`
